### PR TITLE
Move contributors into separate component

### DIFF
--- a/components/Contributors.js
+++ b/components/Contributors.js
@@ -1,0 +1,15 @@
+
+export default function Contributors(){
+  return (
+    <div className="contributors">
+    {/* Add your name and Github here! */}
+    <h2>Developers</h2>
+    <div className="names">
+      <a href="https://github.com/SamSamskies" target="_blank">Sam</a>
+      <a href="https://github.com/MarkWillisford" target="_blank">Mark</a>
+      <a href="https://github.com/itfibonacci" target="_blank">Levon</a>
+      <a href="https://github.com/karleee" target="_blank">Karen</a>
+    </div>
+  </div>
+  )
+}

--- a/components/Contributors.js
+++ b/components/Contributors.js
@@ -1,15 +1,28 @@
 
-export default function Contributors(){
+export default function Contributors() {
+  /* 
+  
+  Add your name and Github here! 
+  
+  */
+  const people = [
+    { name: "Sam", githubLink: "https://github.com/SamSamskies" },
+    { name: "Mark", githubLink: "https://github.com/MarkWillisford" },
+    { name: "Levon", githubLink: "https://github.com/itfibonacci" },
+    { name: "Karen", githubLink: "https://github.com/karleee" },
+    { name: "James", githubLink: "https://github.com/ngjamesng" },
+  ];
+
+  const ContributorLink = ({ person }) => (
+    <a href={person.githubLink} target="_blank">{person.name}</a>
+  )
+
   return (
     <div className="contributors">
-    {/* Add your name and Github here! */}
-    <h2>Developers</h2>
-    <div className="names">
-      <a href="https://github.com/SamSamskies" target="_blank">Sam</a>
-      <a href="https://github.com/MarkWillisford" target="_blank">Mark</a>
-      <a href="https://github.com/itfibonacci" target="_blank">Levon</a>
-      <a href="https://github.com/karleee" target="_blank">Karen</a>
+      <h2>Developers</h2>
+      <div className="names">
+        {people.map(p => <ContributorLink person={p} key={p.githubLink} />)}
+      </div>
     </div>
-  </div>
-  )
+  );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import Contributors from '../components/Contributors';
 
 // Importing stylesheets
 import globalStyles from '../styles/global'
@@ -22,16 +23,7 @@ export default function Home() {
             <p className="description">Get started by checking out his GitHub and let's work together to see what we can build.</p>
           </div>
 
-          <div className="contributors">
-            {/* Add your name and Github here! */}
-            <h2>Developers</h2>
-            <div className="names">
-              <a href="https://github.com/SamSamskies" target="_blank">Sam</a>
-              <a href="https://github.com/MarkWillisford" target="_blank">Mark</a>
-              <a href="https://github.com/itfibonacci" target="_blank">Levon</a>
-              <a href="https://github.com/karleee" target="_blank">Karen</a>
-            </div>
-          </div>
+        <Contributors />
         </div>
 
         <div className="grid">

--- a/pages/index.js
+++ b/pages/index.js
@@ -22,7 +22,7 @@ export default function Home() {
             <p className="description">This is a fun idea put forth by Sam for a group of developers.</p>
             <p className="description">Get started by checking out his GitHub and let's work together to see what we can build.</p>
           </div>
-
+        {/* See Contributors component to add your name! */}
         <Contributors />
         </div>
 


### PR DESCRIPTION
The following PR helps declutter index.js a little bit, and would help for readability as the list of contributors grows. 
* Moved contributor names and links into a separate component. 
* Created an array of people, with objects with the properties `name` and `githubLink`, and map over each person to create links. For example: 
```js
const people = [
{name: "name1", githubLink:"https://...."},
{name: "name2", githubLink:"https://...."},
];
```

