### PR TITLE
fix React key prop

### DIFF
--- a/components/Cards.js
+++ b/components/Cards.js
@@ -6,7 +6,7 @@ const Cards = (props) => {
     return (
         <React.Fragment>
             { cardInfo.map(card => (
-                <a href={card.href} className="card" target="_blank">
+                <a href={card.href} className="card" target="_blank" key={card.href}>
                     <div className="card-header">
                         <img src={card.src} alt={card.alt} />
                         <h3>{card.header} &rarr;</h3>


### PR DESCRIPTION
This PR fixes the following bug in `components/Cards.js`: 
```
Warning: Each child in a list should have a unique "key" prop.
```
Anytime we're mapping over an array, every React component created needs a unique "key" for React to efficiently access that component by giving it a stable identity. 
We may be able to get by using the index, however a more unique, robust key would be a property in the object, such as `card.href`. 

