### PR TITLE
Fixed white space "bounce" after scrolling all the way to the right of the screen

### DIFF
--- a/components/NextContainer.js
+++ b/components/NextContainer.js
@@ -1,8 +1,9 @@
 import Cards from "./Cards";
+import styles from "./css/NextContainer.module.css";
 
 const NextContainer = (props) => {
   return (
-    <div className='NextContainer'>
+    <div className={styles.container}>
       <Cards />
     </div>
   );

--- a/components/css/NextContainer.module.css
+++ b/components/css/NextContainer.module.css
@@ -1,0 +1,6 @@
+.container {
+  width: 100%;
+  border-top: 1px solid var(--light-gray);
+  margin-top: 4%;
+  padding-top: 2%;
+}

--- a/styles/global.js
+++ b/styles/global.js
@@ -50,13 +50,6 @@ export default css.global`
     margin-bottom: 0.5%;
   }
 
-  .NextContainer {
-    width: 100%;
-    margin-left: 1.5%;
-    border-top: 1px solid var(--light-gray);
-    margin-top: 4%;
-  }
-
   * {
     box-sizing: border-box;
   }
@@ -95,7 +88,7 @@ export default css.global`
     box-sizing: border-box;
     padding: 3%;
     width: 47%;
-    margin: 2% 3% 2% 0;
+    margin: 2% 1.5% 2% 1.5%;
     border: 2px solid black;
   }
 


### PR DESCRIPTION
## Bug
When user scrolls all the way to the right of the page, white space appears after the "bounce" but does not disappear.
![Screen Shot 2020-08-18 at 1 06 00 PM](https://user-images.githubusercontent.com/13563002/90564111-a8e2db80-e159-11ea-82b5-6ae3ad0849be.png)

## Cause
Width of the four cards containing the Next.js info exceeded the width of its container.

## Fix

- updated `card` css in `global.js` file to manage spacing between cards within 100% of container.
- moved `container` css out of `global.js`